### PR TITLE
add function to set custom output file

### DIFF
--- a/GRAMI_DIRECTED_PATTERNS/src/Dijkstra/main.java
+++ b/GRAMI_DIRECTED_PATTERNS/src/Dijkstra/main.java
@@ -107,9 +107,12 @@ public class main {
 			FileWriter fw;
 			try
 			{
-				String fName = "Output.txt";
-			
-				fw = new FileWriter(fName);
+				if(Settings.outputFileName==null)
+				{
+					System.out.println("You have to specify a output filename");
+					System.exit(1);
+				}
+				fw = new FileWriter(Settings.outputFileName);
 				fw.write(watch.getElapsedTime()/1000.0+"\n");
 				fw.write(sr.result.size()+"\n");
 			

--- a/GRAMI_DIRECTED_PATTERNS/src/utilities/CommandLineParser.java
+++ b/GRAMI_DIRECTED_PATTERNS/src/utilities/CommandLineParser.java
@@ -36,6 +36,9 @@ public class CommandLineParser {
 			//get the dataset filename
 			if(key.compareTo("filename")==0)
 				Settings.fileName = value;
+			// get the output filename
+			if (key.compareTo("outputFileName") == 0)
+				Settings.outputFileName = value;
 			//assign the datasets folder
 			if(key.compareTo("datasetFolder")==0)
 				Settings.datasetsFolder = value;

--- a/GRAMI_DIRECTED_PATTERNS/src/utilities/Settings.java
+++ b/GRAMI_DIRECTED_PATTERNS/src/utilities/Settings.java
@@ -58,4 +58,7 @@ public class Settings
 	
 	//the maximum number of the same label appears in the resulted pattern
 	public static int numLabelAppears = -1;	
+
+	//the output filename
+	public static String outputFileName = null;
 }

--- a/GRAMI_DIRECTED_SUBGRAPHS/src/Dijkstra/main.java
+++ b/GRAMI_DIRECTED_SUBGRAPHS/src/Dijkstra/main.java
@@ -104,9 +104,12 @@ public class main {
 			FileWriter fw;
 			try
 			{
-				String fName = "Output.txt";
-			
-				fw = new FileWriter(fName);
+				if(Settings.outputFileName==null)
+				{
+					System.out.println("You have to specify a output filename");
+					System.exit(1);
+				}
+				fw = new FileWriter(Settings.outputFileName);
 				fw.write(watch.getElapsedTime()/1000.0+"\n");
 				fw.write(sr.result.size()+"\n");
 			

--- a/GRAMI_DIRECTED_SUBGRAPHS/src/utilities/CommandLineParser.java
+++ b/GRAMI_DIRECTED_SUBGRAPHS/src/utilities/CommandLineParser.java
@@ -36,6 +36,8 @@ public class CommandLineParser {
 			//get the dataset filename
 			if(key.compareTo("filename")==0)
 				Settings.fileName = value;
+			if(key.compareTo("outputFileName")==0)
+				Settings.outputFileName = value;
 			//assign the datasets folder
 			if(key.compareTo("datasetFolder")==0)
 				Settings.datasetsFolder = value;

--- a/GRAMI_DIRECTED_SUBGRAPHS/src/utilities/Settings.java
+++ b/GRAMI_DIRECTED_SUBGRAPHS/src/utilities/Settings.java
@@ -46,6 +46,9 @@ public class Settings
 	
 	//the filename
 	public static String fileName = null;
+
+	// the output
+	public static String outputFileName = null;
 	
 	//the maximum number of the same label appears in the resulted pattern
 	public static int numLabelAppears = -1;	

--- a/GRAMI_UNDIRECTED_PATTERNS/src/Dijkstra/main.java
+++ b/GRAMI_UNDIRECTED_PATTERNS/src/Dijkstra/main.java
@@ -102,9 +102,12 @@ public class main {
 			FileWriter fw;
 			try
 			{
-				String fName = "Output.txt";
-			
-				fw = new FileWriter(fName);
+				if(Settings.outputFileName==null)
+				{
+					System.out.println("You have to specify a output filename");
+					System.exit(1);
+				}
+				fw = new FileWriter(Settings.outputFileName);
 				fw.write(watch.getElapsedTime()/1000.0+"\n");
 				fw.write(sr.result.size()+"\n");
 			

--- a/GRAMI_UNDIRECTED_PATTERNS/src/utilities/CommandLineParser.java
+++ b/GRAMI_UNDIRECTED_PATTERNS/src/utilities/CommandLineParser.java
@@ -36,6 +36,9 @@ public class CommandLineParser {
 			//get the dataset filename
 			if(key.compareTo("filename")==0)
 				Settings.fileName = value;
+			// get the output filename
+			if (key.compareTo("outputFileName") == 0)
+				Settings.outputFileName = value;
 			//assign the datasets folder
 			if(key.compareTo("datasetFolder")==0)
 				Settings.datasetsFolder = value;

--- a/GRAMI_UNDIRECTED_PATTERNS/src/utilities/Settings.java
+++ b/GRAMI_UNDIRECTED_PATTERNS/src/utilities/Settings.java
@@ -53,4 +53,7 @@ public class Settings
 	
 	//the maximum number of the same label appears in the resulted pattern
 	public static int numLabelAppears = -1;
+
+	//the output filename
+	public static String outputFileName = null;
 }

--- a/GRAMI_UNDIRECTED_SUBGRAPHS/src/Dijkstra/main.java
+++ b/GRAMI_UNDIRECTED_SUBGRAPHS/src/Dijkstra/main.java
@@ -109,9 +109,12 @@ public class main {
 			FileWriter fw;
 			try
 			{
-				String fName = "Output.txt";
-			
-				fw = new FileWriter(fName);
+				if(Settings.outputFileName==null)
+				{
+					System.out.println("You have to specify a output filename");
+					System.exit(1);
+				}
+				fw = new FileWriter(Settings.outputFileName);
 				fw.write(watch.getElapsedTime()/1000.0+"\n");
 				fw.write(sr.result.size()+"\n");
 			

--- a/GRAMI_UNDIRECTED_SUBGRAPHS/src/utilities/CommandLineParser.java
+++ b/GRAMI_UNDIRECTED_SUBGRAPHS/src/utilities/CommandLineParser.java
@@ -34,6 +34,9 @@ public class CommandLineParser {
 			// get the dataset filename
 			if (key.compareTo("filename") == 0)
 				Settings.fileName = value;
+			// get the output filename
+			if (key.compareTo("outputFileName") == 0)
+				Settings.outputFileName = value;
 			// assign the datasets folder
 			if (key.compareTo("datasetFolder") == 0)
 				Settings.datasetsFolder = value;

--- a/GRAMI_UNDIRECTED_SUBGRAPHS/src/utilities/Settings.java
+++ b/GRAMI_UNDIRECTED_SUBGRAPHS/src/utilities/Settings.java
@@ -46,6 +46,9 @@ public class Settings
 	//given frequency, if not given then its value is -1
 	public static int frequency = -1;
 	
-		//the filename
+	//the filename
 	public static String fileName = null;
+
+	//the output filename
+	public static String outputFileName = null;
 }

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ EXAMPLES:
 =====
 
     1- Show GraMi breif help: "./grami -h"
-    2- Find frequent subgraphs in the "mico" undirected graph, with minimum frequency = 14000: "./grami -f mico.lg -s 14000 -t 0 -p 0"
-    3- Find frequent subgraphs in the "mico" undirected graph, with minimum frequency = 9340 and approximation: "./grami -f mico.lg -s 9340 -t 0 -p 0 -approxA 0.0002 -approxB=0"
-    4- Find frequent patterns in the "citeseer" directed graph, with minimum frequency = 160 and maximum distance bound (edge weight) = 200: "./grami -f citeseer.lg -s 160 -t 1 -p 1 -d 200"
+    2- Find frequent subgraphs in the "mico" undirected graph, with minimum frequency = 14000: "./grami -f mico.lg -o myoutput.txt -s 14000 -t 0 -p 0"
+    3- Find frequent subgraphs in the "mico" undirected graph, with minimum frequency = 9340 and approximation: "./grami -f mico.lg -o myoutput.txt -s 9340 -t 0 -p 0 -approxA 0.0002 -approxB=0"
+    4- Find frequent patterns in the "citeseer" directed graph, with minimum frequency = 160 and maximum distance bound (edge weight) = 200: "./grami -f citeseer.lg -o myoutput.txt -s 160 -t 1 -p 1 -d 200"
 
 Contributors
 =====

--- a/README.txt
+++ b/README.txt
@@ -40,19 +40,22 @@ INSTALLATION:
 
 EXAMPLES:
 
-Run any of the following examples, results will be on "Output.txt". First line shows elapsed time in seconds. Second line has the number of frequent subgraphs, then frequent subgraphs are listed in the subsequent lines.
+Run any of the following examples, you should set the your output file.
+ First line shows elapsed time in seconds. 
+ Second line has the number of frequent subgraphs.
+ Then frequent subgraphs are listed in the subsequent lines.
 
 1- Show GraMi breif help:
 	./grami -h
 
 2- Find frequent subgraphs in the "mico" undirected graph, with minimum
 frequency = 14000:
-	./grami -f mico.lg -s 14000 -t 0 -p 0
+    ./grami -f mico.lg -o myoutput.txt -s 14000 -t 0 -p 0
 
 3- Find frequent subgraphs in the "mico" undirected graph, with minimum
 frequency = 9340 and approximation:
-	./grami -f mico.lg -s 9340 -t 0 -p 0 -approxA 0.0002 -approxB=0
+    ./grami -f mico.lg -o myoutput.txt -s 9340 -t 0 -p 0 -approxA 0.0002 -approxB=0
 
 4- Find frequent patterns in the "citeseer" directed graph, with minimum
 frequency = 160 and maximum distance bound (edge weight) = 200:
-	./grami -f citeseer.lg -s 160 -t 1 -p 1 -d 200
+	./grami -f citeseer.lg -o myoutput.txt -s 160 -t 1 -p 1 -d 200

--- a/grami
+++ b/grami
@@ -14,6 +14,7 @@ while test $# -gt 0; do
                         echo " "
 			echo "-h, --help                show brief help"
                         echo "-f,			graph filename (*.lg)"
+						echo "-o,			output file name"
                         echo "-s,			minimum frequency"
                         echo "-t,			graph type: 0 for undirected graphs, 1 for directed graph"
                         echo "-p,			mining type: 0 for subgraphs mining, 1 for patterns graph"
@@ -28,6 +29,13 @@ while test $# -gt 0; do
 			shift
 			if test $# -gt 0; then
                                 file=$1
+			fi
+			shift
+			;;
+		-o)
+			shift
+			if test $# -gt 0; then
+                                outputfile=$1
 			fi
 			shift
 			;;
@@ -87,7 +95,7 @@ while test $# -gt 0; do
 done
 
 #printing some output to the users
-echo "Dataset: $file"
+echo "Dataset: $file, output file: $outputfile"
 
 if [ $type -eq 1 ]
 then
@@ -135,5 +143,5 @@ fi
 
 #Running Grami
 echo "Starting GraMi ...";
-java -cp ./$prog/bin Dijkstra.main freq=$frequency filename=$file datasetFolder=./Datasets/ distance=$distance type=$type mlabels=false maxLabelAppearance=$labels approximate=$alpha approxConst=$beta
+java -cp ./$prog/bin Dijkstra.main freq=$frequency filename=$file datasetFolder=./Datasets/ distance=$distance type=$type mlabels=false maxLabelAppearance=$labels approximate=$alpha approxConst=$beta outputFileName=$outputfile
 echo "GraMi Finished."


### PR DESCRIPTION
the original software sets a fixed output file to a **Output.txt**, this prevents parallel mining using multiple threads. I added a new function that users can set their own output file, so they can run multiple programs in parallel and gather the output in custom files.